### PR TITLE
Add generation of graph from the atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ The project was build with the version of Python 3.7
 | `--clean`               | `None`  	               | Reset the cache of the project                    |
 
 Here is the **list of typeGraph**: 
-- Cycle graphs
-- Tree graphs
-- Bipartite graphs
-- Outer planar graphs
-- Grid graphs
+- Cycle graphs (*cycle*)
+- Tree graphs (*tree*)
+- Bipartite graphs (*bipartite*)
+- Outer planar graphs (*outerplanar*)
+- Grid graphs (*grid*)
+- Graph from the atlas (*atlas*)
+
+> :information_source: **The atlas graph is a list handled by *networkx library*.**: The number of graph available is 1253
 
 ## Run Locally
 
@@ -86,6 +89,7 @@ Right now the program can generate the following type of graphs:
 - Outer planar graphs
 - Grid graphs
 - Complex graph
+- Atlas graph
 
 The implemented drawing algorithms are:
 - None
@@ -95,4 +99,5 @@ The implemented drawing algorithms are:
 
 - [@thib-info](https://www.github.com/thib-info)
 - [@TomasVdS](https://github.com/TomasVdS)
+- [@TiboDeCock](https://github.com/TiboDeCock)
 

--- a/graph-drawing/graph/factory.py
+++ b/graph-drawing/graph/factory.py
@@ -194,13 +194,24 @@ def generate_complex_graph(num_vertices=3, num_edges=2, num_graph_types=3, seed=
     return complex_graph
 
 
-def generate_atlas_graph(weight=False):
+def generate_atlas_graph(index=-1, weight=False):
     """
     Generation of a graph coming form the atlas: https://global.oup.com/academic/product/an-atlas-of-graphs-9780198526506?cc=fr&lang=en&
     Number of available graph: 1253
+
+    !!! If you want a random graph specify -n -1 during the generation of the graph !!!
     """
+    correct = True
     max_length = 1253
-    index = random.randint(1, max_length)
+    if index <= -1 or index > 1253:
+        print(
+            "Your index is invalid and will be generated randomly\nRules to follow:\n1. Positive number\n2. Less than "
+            "1253")
+        correct = False
+
+    if not correct:
+        index = random.randint(1, max_length)
+
     graph = nx.classes.graph.Graph(nx.graph_atlas(index))
 
     addPosition(graph)

--- a/graph-drawing/main.py
+++ b/graph-drawing/main.py
@@ -82,7 +82,7 @@ def generateGraph():
             graph_to_print = 'grid_graph.json'
 
         if args.graph_type == 'atlas' or args.graph_type == 'all':
-            graph.generate_atlas_graph(args.weight)
+            graph.generate_atlas_graph(args.num_nodes[0], args.weight)
             graph_to_print = 'atlas_graph.json'
 
     if hasattr(args, 'complex'):


### PR DESCRIPTION
Possibility to create a graph coming from the atlas of the networkx library after the first meetings with the coaches.
To test it: 
`python3 ./main --generate -gt atlas -n -1`

The option *-n* is here to specify the index of the graph we want to generate (0<n<1253).
If the value of *-n* is equal to -1, it means that we choose a random graph into the atlas. 

Also update the REAME.md base on the new feature 